### PR TITLE
Simplify logprob of Radial distribution

### DIFF
--- a/src/veriflow/distributions.py
+++ b/src/veriflow/distributions.py
@@ -156,14 +156,14 @@ class RadialDistribution(torch.distributions.Distribution):
     
     Args:
         loc: Location of the distribution
-        radial_distribution: Distribution of the radial component
+        norm_distribution: Distribution of the radial component
         p: Exponent of the Lp norm used to define the distribution. Currently, p = 1, 2, and inf are supported.
     """
     arg_constraints = {"loc": constraints.real}
     support = constraints.positive
     has_enumerate_support = False  
     
-    def __init__(self, loc: torch.Tensor, radial_distribution: torch.distributions.Distribution, p: float, device: str = "cpu"):
+    def __init__(self, loc: torch.Tensor, norm_distribution: torch.distributions.Distribution, p: float, device: str = "cpu"):
         if not isinstance(p, float):
             raise ValueError("p must be a float.")
         if p <= 0:
@@ -171,7 +171,7 @@ class RadialDistribution(torch.distributions.Distribution):
         
         self.device = device
         self.loc = loc.to(device)
-        self.radial_distribution = radial_distribution
+        self.norm_distribution = norm_distribution
         self.p = p
         self.dim = loc.shape[0]
         self.unit_ball_distribution = UniformUnitLpBall(self.dim, p)
@@ -187,7 +187,7 @@ class RadialDistribution(torch.distributions.Distribution):
         else:
             sample_shape = tuple(sample_shape)
         
-        r = self.radial_distribution.sample(sample_shape).to(self.device)
+        r = self.norm_distribution.sample(sample_shape).to(self.device)
         r = r.repeat(*[1 for _ in sample_shape], self.dim)
         u = self.unit_ball_distribution.sample(sample_shape).to(self.device)
         x = r * u
@@ -201,13 +201,10 @@ class RadialDistribution(torch.distributions.Distribution):
         """Computes the log probability of the points x under the distribution."""
         x = x - self.loc
         r = x.norm(dim=-1, p=self.p)
-        log_prob_radial = self.radial_distribution.log_prob(r)
-        delta_v
-        log_prob_unit_ball = self.unit_ball_distribution.log_prob(x / r.unsqueeze(-1))
+        log_prob_norm = self.norm_distribution.log_prob(r)
+        log_dV = self.log_delta_volume(self.p, r)
         
-        conv_log_abs_det_jacobian = (self.dim - 1) * torch.log(r)
-        
-        return log_prob_radial + log_prob_unit_ball - conv_log_abs_det_jacobian 
+        return log_prob_norm - log_dV
     
     def log_delta_volume(p: int, r: Union[float, torch.Tensor]) -> Union[float. torch.Tensor]:
         """Computes the differential log-volume of an $L^p$ ball with radius r. 
@@ -230,7 +227,7 @@ class RadialDistribution(torch.distributions.Distribution):
            )
            log_dv = log_numerator - math.lgamma((d / 2) + 1)
         elif p == math.inf:
-           # V_2^d'(r) = d * (pi)^(d/2) * r^(d-1) / Gamma(d/2 + 1)
+           # V_\infty^d'(r) = d * (pi)^(d/2) * r^(d-1) / Gamma(d/2 + 1)
            log_dv = math.log(self.dim) + self.dim * math.log(2) + (self.dim - 1) * math.log(r)  
         else:
             raise ValueError(f"p={p} not implemented. Use p=1,2, or infinity")

--- a/src/veriflow/distributions.py
+++ b/src/veriflow/distributions.py
@@ -202,8 +202,37 @@ class RadialDistribution(torch.distributions.Distribution):
         x = x - self.loc
         r = x.norm(dim=-1, p=self.p)
         log_prob_radial = self.radial_distribution.log_prob(r)
+        delta_v
         log_prob_unit_ball = self.unit_ball_distribution.log_prob(x / r.unsqueeze(-1))
         
         conv_log_abs_det_jacobian = (self.dim - 1) * torch.log(r)
         
         return log_prob_radial + log_prob_unit_ball - conv_log_abs_det_jacobian 
+    
+    def log_delta_volume(p: int, r: Union[float, torch.Tensor]) -> Union[float. torch.Tensor]:
+        """Computes the differential log-volume of an $L^p$ ball with radius r. 
+        Currently, $p=1,2,\text{ or }\infty$ is implemented
+        
+        Args:
+            p: p norm
+            r: radius (batch)
+        Returns:
+            Differential volume (batch)
+        """
+        if p == 1:
+           # V_1^d'(r) = (2r)**(d-1) / (d-1)!
+           log_denominator = sum([math.log(i) for i in range(1, self.dim)])
+           log_dv = math.log(2) * d + math.log(r) * (d-1) - ldfac
+        elif p == 2:
+           # V_2^d'(r) = d * (pi)^(d/2) * r^(d-1) / Gamma(d/2 + 1)
+           log_numerator = (
+               math.log(self.dim) + (self.dim / 2) * math.log(math.pi) + (d - 1) * math.log(r)
+           )
+           log_dv = log_numerator - math.lgamma((d / 2) + 1)
+        elif p == math.inf:
+           # V_2^d'(r) = d * (pi)^(d/2) * r^(d-1) / Gamma(d/2 + 1)
+           log_dv = math.log(self.dim) + self.dim * math.log(2) + (self.dim - 1) * math.log(r)  
+        else:
+            raise ValueError(f"p={p} not implemented. Use p=1,2, or infinity")
+        
+        return log_dv


### PR DESCRIPTION
declutters the log_prob method of the RadianDistribution. Provides clearer decomposition of the log-likelihood computation according to the formula $\log p_{R_\rho^p}(x) = \ln p_\rho(|x|_p) - \ln\left(\frac{\partial V_p(r)}{\partial r}(|x|_p) \right)$ 